### PR TITLE
feat: proxy /api/analyze-graph

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webflux</artifactId>
 		</dependency>
 		<dependency>

--- a/src/main/java/com/wise/app/config/CallbackProps.java
+++ b/src/main/java/com/wise/app/config/CallbackProps.java
@@ -1,0 +1,13 @@
+// com.wise.app.config.CallbackProps
+package com.wise.app.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import lombok.Getter; import lombok.Setter;
+
+@Getter @Setter
+@Component
+@ConfigurationProperties(prefix = "wsie.callback")
+public class CallbackProps {
+    private String apiKey;
+}

--- a/src/main/java/com/wise/app/config/WebClientConfig.java
+++ b/src/main/java/com/wise/app/config/WebClientConfig.java
@@ -1,14 +1,30 @@
+// com/wise/app/config/WebClientConfig.java
 package com.wise.app.config;
 
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.*;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.util.concurrent.TimeUnit;
 
 @Configuration
 public class WebClientConfig {
 
     @Bean
-    public WebClient webClient(WebClient.Builder builder) {
-        return builder.baseUrl("http://localhost:8000").build();
+    public WebClient wsiePyWebClient(@Value("${wsie.py.base-url}") String baseUrl) {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)
+                .doOnConnected(conn -> conn
+                        .addHandlerLast(new ReadTimeoutHandler(10, TimeUnit.SECONDS))
+                        .addHandlerLast(new WriteTimeoutHandler(10, TimeUnit.SECONDS)));
+        return WebClient.builder()
+                .baseUrl(baseUrl)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
     }
 }

--- a/src/main/java/com/wise/app/controller/AnalyzeController.java
+++ b/src/main/java/com/wise/app/controller/AnalyzeController.java
@@ -1,32 +1,23 @@
+// com/wise/app/controller/AnalyzeController.java
 package com.wise.app.controller;
 
 import com.wise.app.dto.AnalyzeResponse;
 import com.wise.app.service.AnalyzeService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.File;
-
 @RestController
-@RequestMapping("/api")
 @RequiredArgsConstructor
+@RequestMapping("/api")
 public class AnalyzeController {
 
     private final AnalyzeService analyzeService;
 
     @PostMapping("/analyze")
-    public AnalyzeResponse analyze(@RequestParam("file") MultipartFile file) throws Exception {
-        // 업로드된 파일 임시 저장
-        File tempFile = File.createTempFile("upload-", file.getOriginalFilename());
-        file.transferTo(tempFile);
-
-        // Python 서버 호출
-        AnalyzeResponse response = analyzeService.analyzeImage(tempFile);
-
-        // 임시 파일 삭제
-        tempFile.delete();
-
-        return response;
+    public ResponseEntity<AnalyzeResponse> analyze(@RequestParam("file") MultipartFile file) {
+        var result = analyzeService.analyzeImage(file);
+        return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/wise/app/controller/AnalyzeGraphController.java
+++ b/src/main/java/com/wise/app/controller/AnalyzeGraphController.java
@@ -1,0 +1,53 @@
+package com.wise.app.controller;
+
+import com.wise.app.dto.GraphAnalyzeResponse;
+import com.wise.app.service.AnalyzeGraphService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+// Swagger/OpenAPI
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.Parameter;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class AnalyzeGraphController {
+
+    private final AnalyzeGraphService service;
+
+    @Operation(summary = "그래프 기반 심화 분석",
+        description = "이미지 업로드 → Python /api/v1/analyze/graph 프록시")
+    @PostMapping(value = "/analyze-graph",
+                 consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+                 produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> analyzeGraph(
+        @Parameter(description = "분석할 이미지 파일", required = true,
+            content = @Content(mediaType = MediaType.APPLICATION_OCTET_STREAM_VALUE,
+                               schema = @Schema(type = "string", format = "binary")))
+        @RequestPart("file") MultipartFile file
+    ) {
+        if (file == null || file.isEmpty()) {
+            return ResponseEntity.badRequest().body("file is empty");
+        }
+        try {
+            GraphAnalyzeResponse res = service.analyzeGraph(file);
+            return ResponseEntity.ok(res);
+        } catch (ResponseStatusException ex) {
+            log.error("Analyze-Graph RSE: {}", ex.getReason());
+            return ResponseEntity.status(ex.getStatusCode()).body(ex.getReason());
+        } catch (Exception e) {
+            log.error("Analyze-Graph failed", e);
+            return ResponseEntity.internalServerError().body("Analyze-Graph failed: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/wise/app/controller/PythonCallbackController.java
+++ b/src/main/java/com/wise/app/controller/PythonCallbackController.java
@@ -1,0 +1,45 @@
+// API Key 검증 + 수신
+package com.wise.app.controller;
+
+import com.wise.app.config.CallbackProps;
+import com.wise.app.dto.AnalyzeCallbackRequest;
+import com.wise.app.dto.AnalyzeCallbackResponse;
+import com.wise.app.service.PythonCallbackService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Objects;
+
+@RestController
+@RequestMapping("/api/v1/callback")
+@RequiredArgsConstructor
+public class PythonCallbackController {
+
+    private final PythonCallbackService callbackService;
+    private final CallbackProps props;
+
+    @PostMapping("/analyze")
+    public ResponseEntity<AnalyzeCallbackResponse> receiveAnalyzeResult(
+            @RequestHeader(name = "X-API-KEY", required = false) String key,
+            @Valid @RequestBody AnalyzeCallbackRequest request
+    ) {
+        if (!Objects.equals(props.getApiKey(), key)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        try {
+            String id = callbackService.saveAnalyzeResult(request);
+            return ResponseEntity.ok(new AnalyzeCallbackResponse(id, "OK"));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new AnalyzeCallbackResponse(null, "ERROR: " + e.getMessage()));
+        }
+    }
+
+    @GetMapping("/ping")
+    public ResponseEntity<String> ping() {
+        return ResponseEntity.ok("READY");
+    }
+}

--- a/src/main/java/com/wise/app/controller/RecommendController.java
+++ b/src/main/java/com/wise/app/controller/RecommendController.java
@@ -1,0 +1,24 @@
+// src/main/java/com/wise/app/controller/RecommendController.java
+package com.wise.app.controller;
+
+import com.wise.app.dto.RecommendByIngredientsRequest;
+import com.wise.app.dto.RecipeItem;
+import com.wise.app.service.RecommendService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/recommend")
+public class RecommendController {
+
+    private final RecommendService service;
+
+    @PostMapping("/by-ingredients")
+    public ResponseEntity<List<RecipeItem>> byIngredients(@Valid @RequestBody RecommendByIngredientsRequest req) {
+        return ResponseEntity.ok(service.recommendByIngredients(req));
+    }
+}

--- a/src/main/java/com/wise/app/dto/AnalyzeCallbackRequest.java
+++ b/src/main/java/com/wise/app/dto/AnalyzeCallbackRequest.java
@@ -1,0 +1,30 @@
+// src/main/java/com/wise/app/dto/AnalyzeCallbackRequest.java
+package com.wise.app.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+public class AnalyzeCallbackRequest {
+
+    @NotBlank
+    private String menu;
+
+    @JsonProperty("waste_ratio")
+    @NotNull
+    private Double wasteRatio;
+
+    @NotBlank
+    private String suggestion;
+
+    // 중복 방지/추적용 (Python에서 uuid 생성)
+    @JsonProperty("trace_id")
+    private String traceId;
+
+    // 선택(있으면 저장)
+    @JsonProperty("image_url")
+    private String imageUrl;
+}

--- a/src/main/java/com/wise/app/dto/AnalyzeCallbackResponse.java
+++ b/src/main/java/com/wise/app/dto/AnalyzeCallbackResponse.java
@@ -1,0 +1,11 @@
+// src/main/java/com/wise/app/dto/AnalyzeCallbackResponse.java
+package com.wise.app.dto;
+
+import lombok.*;
+
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+public class AnalyzeCallbackResponse {
+    private String id;      // 저장된 문서 ID (= traceId)
+    private String status;  // "OK"
+}

--- a/src/main/java/com/wise/app/dto/AnalyzeGraphUpload.java
+++ b/src/main/java/com/wise/app/dto/AnalyzeGraphUpload.java
@@ -1,0 +1,14 @@
+// 업로드 DTO
+package com.wise.app.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter @Setter
+public class AnalyzeGraphUpload {
+
+    @Schema(description = "분석할 이미지 파일", type = "string", format = "binary")
+    private MultipartFile file;
+}

--- a/src/main/java/com/wise/app/dto/AnalyzeResponse.java
+++ b/src/main/java/com/wise/app/dto/AnalyzeResponse.java
@@ -1,10 +1,18 @@
+// com/wise/app/dto/AnalyzeResponse.java
 package com.wise.app.dto;
 
-import lombok.Data;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
 
-@Data
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
 public class AnalyzeResponse {
+    @JsonProperty("menu")
     private String menu;
-    private Double waste_ratio;
+
+    @JsonProperty("waste_ratio")
+    private Double wasteRatio;
+
+    @JsonProperty("suggestion")
     private String suggestion;
 }

--- a/src/main/java/com/wise/app/dto/GraphAnalyzeResponse.java
+++ b/src/main/java/com/wise/app/dto/GraphAnalyzeResponse.java
@@ -1,0 +1,15 @@
+package com.wise.app.dto;
+
+import lombok.*;
+import java.util.List;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class GraphAnalyzeResponse {
+    private String report;
+    private List<Improvement> improvements;
+
+    @Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+    public static class Improvement {
+        private String suggestion; // Python improvements[i].suggestion
+    }
+}

--- a/src/main/java/com/wise/app/dto/RecipeItem.java
+++ b/src/main/java/com/wise/app/dto/RecipeItem.java
@@ -1,0 +1,14 @@
+// src/main/java/com/wise/app/dto/RecipeItem.java
+package com.wise.app.dto;
+
+import lombok.*;
+import java.util.List;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class RecipeItem {
+    private String title;
+    private String summary;
+    private Integer recipe_id;     // Python 키에 맞춤 (snake_case)
+    private List<String> ingredients;
+    private String full_recipe;    // Python 키에 맞춤 (snake_case)
+}

--- a/src/main/java/com/wise/app/dto/RecommendByIngredientsRequest.java
+++ b/src/main/java/com/wise/app/dto/RecommendByIngredientsRequest.java
@@ -1,0 +1,14 @@
+package com.wise.app.dto;
+
+import lombok.*;
+import jakarta.validation.constraints.*;
+import java.util.List;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class RecommendByIngredientsRequest {
+    @NotNull @Size(min = 1)
+    private List<@NotBlank String> ingredients;
+
+    @Min(1) @Max(20)
+    private Integer top_k = 3; // Python 키에 맞춤 (snake_case)
+}

--- a/src/main/java/com/wise/app/dto/RecommendRequest.java
+++ b/src/main/java/com/wise/app/dto/RecommendRequest.java
@@ -5,5 +5,5 @@ import lombok.Data;
 @Data
 public class RecommendRequest {
     private String date;              // YYYY-MM-DD
-    private String policy;            // "zero-waste" | "chef" | "mixed"
+    private String policy;
 }

--- a/src/main/java/com/wise/app/resources/application.yaml
+++ b/src/main/java/com/wise/app/resources/application.yaml
@@ -1,8 +1,0 @@
-server:
-  port: 8080
-
-spring:
-  servlet:
-    multipart:
-      max-file-size: 10MB
-      max-request-size: 10MB

--- a/src/main/java/com/wise/app/service/AnalyzeGraphService.java
+++ b/src/main/java/com/wise/app/service/AnalyzeGraphService.java
@@ -1,0 +1,55 @@
+// 그래프 분석 프록시
+package com.wise.app.service;
+
+import com.wise.app.dto.GraphAnalyzeResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.*;
+import org.springframework.http.client.MultipartBodyBuilder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.multipart.MultipartFile;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class AnalyzeGraphService {
+    private final WebClient wsiePyWebClient;
+
+    public GraphAnalyzeResponse analyzeGraph(MultipartFile file) {
+        try {
+            MultipartBodyBuilder mb = new MultipartBodyBuilder();
+            mb.part("file", new ByteArrayResource(file.getBytes()){
+                @Override public String getFilename() { return file.getOriginalFilename(); }
+            }).filename(file.getOriginalFilename())
+             .contentType(MediaType.parseMediaType(
+                file.getContentType() == null ? "application/octet-stream" : file.getContentType()
+             ));
+
+            return wsiePyWebClient.post()
+                    .uri("/api/v1/analyze/graph")
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .body(BodyInserters.fromMultipartData(mb.build()))
+                    .exchangeToMono(resp -> {
+                        if (resp.statusCode().is2xxSuccessful()) {
+                            return resp.bodyToMono(GraphAnalyzeResponse.class);
+                        }
+                        // 에러 바디를 그대로 끌어와 전파
+                        return resp.bodyToMono(String.class).defaultIfEmpty("")
+                            .flatMap(body -> {
+                                HttpStatus status = resp.statusCode().is4xxClientError()
+                                        ? HttpStatus.BAD_REQUEST : HttpStatus.BAD_GATEWAY; // PY 문제는 502로 맵핑
+                                return Mono.error(new ResponseStatusException(status, "PY error: " + body));
+                            });
+                    })
+                    .block();
+        } catch (ResponseStatusException e) {
+            throw e; // 컨트롤러로 전달
+        } catch (Exception e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Analyze-Graph proxy failed: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/wise/app/service/AnalyzeService.java
+++ b/src/main/java/com/wise/app/service/AnalyzeService.java
@@ -1,29 +1,42 @@
+// 이미지 멀티파트 → Python 프록시
 package com.wise.app.service;
 
 import com.wise.app.dto.AnalyzeResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.*;
+import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.http.MediaType;
-import org.springframework.core.io.FileSystemResource;
-
-import java.io.File;
+import org.springframework.web.multipart.MultipartFile;
+import reactor.core.publisher.Mono;
 
 @Service
 @RequiredArgsConstructor
 public class AnalyzeService {
 
-    private final WebClient webClient;
+    private final WebClient wsiePyWebClient;
 
-    public AnalyzeResponse analyzeImage(File imageFile) {
-        return webClient.post()
-                .uri("/analyze")
-                .contentType(MediaType.MULTIPART_FORM_DATA)
-                .bodyValue(new org.springframework.util.LinkedMultiValueMap<String, Object>() {{
-                    add("file", new FileSystemResource(imageFile));
-                }})
-                .retrieve()
-                .bodyToMono(AnalyzeResponse.class)
-                .block();
+    public AnalyzeResponse analyzeImage(MultipartFile file) {
+        try {
+            MultipartBodyBuilder mb = new MultipartBodyBuilder();
+            mb.part("file", new ByteArrayResource(file.getBytes()){
+                @Override public String getFilename() { return file.getOriginalFilename(); }
+            }).filename(file.getOriginalFilename())
+             .contentType(MediaType.parseMediaType(file.getContentType() == null ? "application/octet-stream" : file.getContentType()));
+
+            return wsiePyWebClient.post()
+                    .uri("/analyze")
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .body(BodyInserters.fromMultipartData(mb.build()))
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, resp ->
+                            resp.bodyToMono(String.class).flatMap(body -> Mono.error(new RuntimeException("PY error: " + body))))
+                    .bodyToMono(AnalyzeResponse.class)
+                    .block(); // 단순 동기화 (필요 시 비동기로 전환)
+        } catch (Exception e) {
+            throw new RuntimeException("Analyze proxy failed: " + e.getMessage(), e);
+        }
     }
 }

--- a/src/main/java/com/wise/app/service/PythonCallbackService.java
+++ b/src/main/java/com/wise/app/service/PythonCallbackService.java
@@ -1,0 +1,43 @@
+// Service: Firestore 저장
+package com.wise.app.service;
+
+import com.google.api.core.ApiFuture;
+import com.google.cloud.Timestamp;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.SetOptions;
+import com.google.firebase.cloud.FirestoreClient;
+import com.wise.app.dto.AnalyzeCallbackRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PythonCallbackService {
+
+    public String saveAnalyzeResult(AnalyzeCallbackRequest req) throws Exception {
+        Firestore db = FirestoreClient.getFirestore();
+
+        String id = Optional.ofNullable(req.getTraceId())
+                .filter(s -> !s.isBlank())
+                .orElse(UUID.randomUUID().toString());
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("menu", req.getMenu());
+        data.put("wasteRatio", req.getWasteRatio());  // 카멜케이스로 저장
+        data.put("suggestion", req.getSuggestion());
+        data.put("imageUrl", req.getImageUrl());
+        data.put("createdAt", Timestamp.now());
+
+        ApiFuture<?> future = db.collection("analyze_results")
+                .document(id)
+                .set(data, SetOptions.merge());
+
+        future.get(); // 동기 저장 보장(필요 시 비동기로 전환 가능)
+        return id;
+    }
+}

--- a/src/main/java/com/wise/app/service/RecommendService.java
+++ b/src/main/java/com/wise/app/service/RecommendService.java
@@ -1,0 +1,35 @@
+// src/main/java/com/wise/app/service/RecommendService.java
+package com.wise.app.service;
+
+import com.wise.app.dto.RecommendByIngredientsRequest;
+import com.wise.app.dto.RecipeItem;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RecommendService {
+    private final WebClient wsiePyWebClient;
+
+    public List<RecipeItem> recommendByIngredients(RecommendByIngredientsRequest req) {
+        try {
+            return wsiePyWebClient.post()
+                    .uri("/api/v1/recommend/by-ingredients")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(req) // snake_case 필드 그대로 전달
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, resp ->
+                        resp.bodyToMono(String.class).flatMap(b -> Mono.error(new RuntimeException("PY error: " + b))))
+                    .bodyToFlux(RecipeItem.class)
+                    .collectList()
+                    .block();
+        } catch (Exception e) {
+            throw new RuntimeException("Recommend proxy failed: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/wise/app/service/ReportService.java
+++ b/src/main/java/com/wise/app/service/ReportService.java
@@ -14,28 +14,28 @@ public class ReportService {
 
     /** 폐기비용 합계는 WasteDetail.cost 합산을 가정 */
     public ReportSummary summary(String start, String end) throws ExecutionException, InterruptedException {
-    var col = firestore.collection("waste_reports");
-    var q = col.whereGreaterThanOrEqualTo("date", start)
-               .whereLessThanOrEqualTo("date", end);
-    var snaps = q.get().get();
+        var col = firestore.collection("waste_reports");
+        var q = col.whereGreaterThanOrEqualTo("date", start)
+                .whereLessThanOrEqualTo("date", end);
+        var snaps = q.get().get();
 
-    int wasteCostSum = 0;
-    for (DocumentSnapshot d : snaps.getDocuments()) {
-        var details = (java.util.List<java.util.Map<String,Object>>) d.get("details");
-        if (details != null) {
-            for (var it : details) {
-                Object cost = it.get("cost");
-                if (cost instanceof Number n) wasteCostSum += n.intValue();
+        int wasteCostSum = 0;
+        for (DocumentSnapshot d : snaps.getDocuments()) {
+            var details = (java.util.List<java.util.Map<String,Object>>) d.get("details");
+            if (details != null) {
+                for (var it : details) {
+                    Object cost = it.get("cost");
+                    if (cost instanceof Number n) wasteCostSum += n.intValue();
+                }
             }
         }
-    }
 
-    double carbon = Math.round((wasteCostSum / 4500.0) * 10) / 10.0;
-    return ReportSummary.builder()
-            .start(start).end(end)
-            .wasteCost(wasteCostSum)
-            .carbonReductionKg(carbon)
-            .marginImprovement(0.05)
-            .build();
-}
+        double carbon = Math.round((wasteCostSum / 4500.0) * 10) / 10.0;
+        return ReportSummary.builder()
+                .start(start).end(end)
+                .wasteCost(wasteCostSum)
+                .carbonReductionKg(carbon)
+                .marginImprovement(0.05)
+                .build();
+    }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,19 @@
+server:
+  port: 8080
+
+wsie:
+  callback:
+    api-key: "f74599335ac633c1aa6841ae8e8d1d285f27eb7a14cf26e1d52ad789794ead09"
+  py:
+    base-url: "http://localhost:8000"
+
+spring:
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+springdoc:
+  swagger-ui:
+    path: /swagger-ui
+  api-docs:
+    path: /v3/api-docs


### PR DESCRIPTION
- feat: proxy /api/analyze-graph → Python /api/v1/analyze/graph (multipart)
- chore: add wsie.py.base-url, multipart limits; enable swagger-ui
- refactor: propagate Python error body to client (4xx→400, 5xx→502)